### PR TITLE
Refactor routing and streamline map interface

### DIFF
--- a/public/data/elements.json
+++ b/public/data/elements.json
@@ -6,8 +6,14 @@
       "layerId": "poi",
       "type": "npc",
       "name": "Marco el Mensajero",
-      "position": [960, 720],
-      "icon": { "kind": "pin", "colorVar": "--pin-npc" },
+      "position": [
+        960,
+        720
+      ],
+      "icon": {
+        "kind": "pin",
+        "colorVar": "--pin-npc"
+      },
       "panelId": "panel:npc_marco"
     },
     {
@@ -16,9 +22,36 @@
       "layerId": "poi",
       "type": "shop",
       "name": "Almacén Bristleback",
-      "position": [1120, 820],
-      "icon": { "kind": "pin", "colorVar": "--pin-shop" },
+      "position": [
+        1120,
+        820
+      ],
+      "icon": {
+        "kind": "pin",
+        "colorVar": "--pin-shop"
+      },
       "panelId": "panel:shop_bristleback"
+    },
+    {
+      "id": "portal:tablon",
+      "sceneId": "hispania",
+      "layerId": "poi",
+      "type": "generic",
+      "name": "Tablón de anuncios",
+      "position": [
+        1040,
+        680
+      ],
+      "icon": {
+        "kind": "pin",
+        "colorVar": "--pin-generic"
+      },
+      "navigation": {
+        "sceneId": "tablon",
+        "layers": [
+          "posts"
+        ]
+      }
     },
     {
       "id": "quest:bandits_note",
@@ -26,8 +59,16 @@
       "layerId": "posts",
       "type": "image",
       "name": "Aviso Bandidos",
-      "position": [760, 540],
-      "sprite": { "src": "boards/notes/bandits.svg", "width": 360, "height": 240, "rotation": -6 },
+      "position": [
+        760,
+        540
+      ],
+      "sprite": {
+        "src": "boards/notes/bandits.svg",
+        "width": 360,
+        "height": 240,
+        "rotation": -6
+      },
       "panelId": "panel:quest_bandits"
     }
   ]

--- a/public/data/scenes.json
+++ b/public/data/scenes.json
@@ -4,25 +4,55 @@
       "id": "hispania",
       "name": "Hispania",
       "background": "maps/villazarcillo.png",
-      "size": { "width": 2048, "height": 2048 },
-      "initialView": { "center": [2048, 2048], "zoom": -1 },
+      "size": {
+        "width": 2048,
+        "height": 2048
+      },
+      "initialView": {
+        "center": [
+          2048,
+          2048
+        ],
+        "zoom": -1
+      },
       "minZoom": -2,
       "maxZoom": 2,
       "layers": [
-        { "id": "poi", "name": "Puntos", "visible": true },
-        { "id": "routes", "name": "Rutas", "visible": false }
+        {
+          "id": "poi",
+          "name": "Puntos",
+          "visible": true
+        },
+        {
+          "id": "routes",
+          "name": "Rutas",
+          "visible": false
+        }
       ]
     },
     {
       "id": "tablon",
       "name": "Tablón",
       "background": "boards/base.svg",
-      "size": { "width": 1600, "height": 1100 },
-      "initialView": { "center": [800, 550], "zoom": 0 },
-      "minZoom": -1,
-      "maxZoom": 1,
+      "size": {
+        "width": 1600,
+        "height": 1100
+      },
+      "initialView": {
+        "center": [
+          800,
+          550
+        ],
+        "zoom": 0
+      },
+      "minZoom": 0,
+      "maxZoom": 0,
       "layers": [
-        { "id": "posts", "name": "Anuncios", "visible": true }
+        {
+          "id": "posts",
+          "name": "Anuncios",
+          "visible": true
+        }
       ]
     }
   ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Navigate, useLocation, useNavigate, useParams, useRoutes } from 'react-router-dom'
+import type { NavigateFunction } from 'react-router-dom'
 import { CampHub } from './components/CampHub'
 import { loadData } from './lib/dataLoader'
-import type { DataBundle, HubElement, Scene, SceneLayer } from './lib/types'
-import { parseQuery } from './lib/queryParams'
+import type {
+  DataBundle,
+  HubElement,
+  HubNavigationTarget,
+  Scene,
+  SceneLayer,
+} from './lib/types'
 
 type RouteParams = {
   sceneId?: string
-  focusId?: string
-  layerIds?: string
+  [key: string]: string | undefined
 }
 
 type LayerState = {
@@ -16,14 +21,20 @@ type LayerState = {
   explicitEmpty: boolean
 }
 
-function App() {
+type HubViewState = {
+  scene: Scene
+  layerState: LayerState
+  focusElement?: HubElement
+}
+
+function HubExperience() {
   const [data, setData] = useState<DataBundle | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [viewState, setViewState] = useState<HubViewState | null>(null)
   const navigate = useNavigate()
   const location = useLocation()
   const params = useParams<RouteParams>()
-  const queryHydratedRef = useRef(false)
 
   useEffect(() => {
     loadData()
@@ -45,97 +56,63 @@ function App() {
     return data ? new Map<string, HubElement>(data.elements.map((element) => [element.id, element])) : new Map()
   }, [data])
 
-  useEffect(() => {
-    if (!data || queryHydratedRef.current) {
-      return
-    }
-
-    const query = parseQuery(location.search)
-    const hasQuery = Boolean(query.scene || query.focus || (query.layer && query.layer.length > 0))
-    const defaultScene = data.scenes[0]
-    if (!defaultScene) {
-      return
-    }
-
-    const sceneFromConfig = scenesMap.get(data.config.defaultScene) ?? defaultScene
-
-    if (hasQuery) {
-      const focusElement = query.focus ? elementsMap.get(query.focus) : undefined
-      const requestedScene = query.scene ? scenesMap.get(query.scene) : undefined
-      const targetScene = focusElement ? scenesMap.get(focusElement.sceneId) ?? requestedScene : requestedScene
-      const finalScene = targetScene ?? sceneFromConfig
-      const sanitizedLayers = sanitizeLayersFromArray(finalScene, query.layer)
-      navigate(
-        buildRoute({
-          sceneId: finalScene.id,
-          focusId: focusElement?.id ?? query.focus ?? undefined,
-          layers: serializeLayers(finalScene, sanitizedLayers.set, sanitizedLayers.explicitEmpty),
-        }),
-        { replace: true },
-      )
-      queryHydratedRef.current = true
-      return
-    }
-
-    if (!params.sceneId) {
-      navigate(buildRoute({ sceneId: sceneFromConfig.id }), { replace: true })
-    }
-
-    queryHydratedRef.current = true
-  }, [data, elementsMap, location.search, navigate, params.sceneId, scenesMap])
+  const legacyFocus = getLegacySegment(params['*'], 'focus')
+  const legacyLayers = getLegacySegment(params['*'], 'layers')
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search])
+  const focusParam = searchParams.get('focus') ?? legacyFocus ?? undefined
+  const layersParam = searchParams.get('layers') ?? searchParams.get('layer') ?? legacyLayers ?? undefined
 
   useEffect(() => {
-    if (!data || !queryHydratedRef.current) {
+    if (!data || data.scenes.length === 0) {
       return
     }
 
-    const routeSceneId = params.sceneId
-    if (!routeSceneId) {
-      return
+    const sanitized = sanitizeRoute({
+      data,
+      scenesMap,
+      elementsMap,
+      requestedSceneId: params.sceneId,
+      focusId: focusParam,
+      layersParam,
+    })
+
+    setViewState({
+      scene: sanitized.scene,
+      layerState: sanitized.layerState,
+      focusElement: sanitized.focusElement,
+    })
+
+    const canonicalSearch = sanitized.search
+    const currentSearch = location.search.startsWith('?')
+      ? location.search.slice(1)
+      : location.search
+    const needsRedirect =
+      params.sceneId !== sanitized.scene.id ||
+      canonicalSearch !== currentSearch ||
+      Boolean(params['*'])
+
+    if (needsRedirect) {
+      const target = buildPath(sanitized.scene.id, canonicalSearch)
+      navigate(target, { replace: true })
     }
+  }, [
+    data,
+    elementsMap,
+    focusParam,
+    layersParam,
+    location.search,
+    navigate,
+    params.sceneId,
+    params['*'],
+    scenesMap,
+  ])
 
-    const defaultScene = scenesMap.get(data.config.defaultScene) ?? data.scenes[0]
-    const currentScene = scenesMap.get(routeSceneId)
-
-    if (!currentScene) {
-      const fallback = defaultScene ?? data.scenes[0]
-      if (fallback) {
-        navigate(buildRoute({ sceneId: fallback.id }), { replace: true })
-      }
-      return
+  const sceneElements = useMemo<HubElement[]>(() => {
+    if (!data || !viewState) {
+      return []
     }
-
-    if (params.focusId) {
-      const focusElement = elementsMap.get(params.focusId)
-      if (!focusElement) {
-        const layerState = deriveLayerState(currentScene, params.layerIds)
-        navigate(
-          buildRoute({
-            sceneId: currentScene.id,
-            layers: serializeLayers(currentScene, layerState.set, layerState.explicitEmpty),
-          }),
-          { replace: true },
-        )
-        return
-      }
-
-      if (focusElement.sceneId !== currentScene.id) {
-        const focusScene = scenesMap.get(focusElement.sceneId)
-        if (focusScene) {
-          const layerState = deriveLayerState(focusScene, undefined)
-          navigate(
-            buildRoute({
-              sceneId: focusScene.id,
-              focusId: focusElement.id,
-              layers: serializeLayers(focusScene, layerState.set, layerState.explicitEmpty),
-            }),
-            { replace: true },
-          )
-        }
-        return
-      }
-    }
-  }, [data, elementsMap, navigate, params.focusId, params.layerIds, params.sceneId, scenesMap])
+    return data.elements.filter((element) => element.sceneId === viewState.scene.id)
+  }, [data, viewState])
 
   if (loading) {
     return <div className="camp-hub__empty-state">Cargando campamento...</div>
@@ -145,55 +122,13 @@ function App() {
     return <div className="camp-hub__empty-state">{error ?? 'No se encontró contenido.'}</div>
   }
 
-  const defaultScene = scenesMap.get(data.config.defaultScene) ?? data.scenes[0]
-  const routeScene = params.sceneId ? scenesMap.get(params.sceneId) : undefined
-  const activeScene = routeScene ?? defaultScene
-  const layerState = deriveLayerState(activeScene, params.layerIds)
-  const focusElement = params.focusId ? elementsMap.get(params.focusId) : undefined
-
-  const handleSceneChange = (sceneId: string) => {
-    const scene = scenesMap.get(sceneId)
-    if (!scene) {
-      return
-    }
-    const defaults = getDefaultLayers(scene)
-    navigate(
-      buildRoute({
-        sceneId: scene.id,
-        layers: serializeLayers(scene, defaults, false),
-      }),
-    )
-  }
-
-  const handleLayerChange = (next: Set<string>) => {
-    const validIds = new Set(
-      Array.from(next).filter((layerId) =>
-        activeScene.layers.some((layer: SceneLayer) => layer.id === layerId),
-      ),
-    )
-    const defaults = getDefaultLayers(activeScene)
-    const explicitEmpty = validIds.size === 0 && defaults.size > 0
-    navigate(
-      buildRoute({
-        sceneId: activeScene.id,
-        focusId: focusElement?.id,
-        layers: serializeLayers(activeScene, validIds, explicitEmpty),
-      }),
-    )
+  if (!viewState) {
+    return <div className="camp-hub__empty-state">Preparando mapa...</div>
   }
 
   const handleFocusChange = (elementId?: string) => {
     if (!elementId) {
-      navigate(
-        buildRoute({
-          sceneId: activeScene.id,
-          layers: serializeLayers(
-            activeScene,
-            layerState.set,
-            layerState.explicitEmpty && layerState.set.size === 0,
-          ),
-        }),
-      )
+      pushRoute(navigate, viewState.scene, viewState.layerState, undefined)
       return
     }
 
@@ -207,31 +142,48 @@ function App() {
       return
     }
 
-    const isSameScene = scene.id === activeScene.id
-    const targetLayers = isSameScene ? layerState.set : getDefaultLayers(scene)
-    const targetExplicitEmpty = isSameScene ? layerState.explicitEmpty : false
+    const sameScene = scene.id === viewState.scene.id
+    const nextLayerState = sameScene
+      ? viewState.layerState
+      : { set: getDefaultLayers(scene), explicitEmpty: false }
 
-    navigate(
-      buildRoute({
-        sceneId: scene.id,
-        focusId: element.id,
-        layers: serializeLayers(scene, targetLayers, targetExplicitEmpty && targetLayers.size === 0),
-      }),
-    )
+    pushRoute(navigate, scene, nextLayerState, element.id)
+  }
+
+  const handleNavigate = (target: HubNavigationTarget) => {
+    const scene = scenesMap.get(target.sceneId)
+    if (!scene) {
+      return
+    }
+
+    let nextSet: Set<string>
+    let explicitEmpty = false
+
+    if (target.layers === undefined) {
+      nextSet = getDefaultLayers(scene)
+    } else if (target.layers === null) {
+      nextSet = new Set()
+      explicitEmpty = true
+    } else {
+      const valid = target.layers.filter((layerId) =>
+        scene.layers.some((layer: SceneLayer) => layer.id === layerId),
+      )
+      nextSet = valid.length > 0 ? new Set(valid) : getDefaultLayers(scene)
+    }
+
+    pushRoute(navigate, scene, { set: nextSet, explicitEmpty }, target.focusId)
   }
 
   return (
     <CampHub
       config={data.config}
-      scenes={data.scenes}
-      elements={data.elements}
+      scene={viewState.scene}
+      elements={sceneElements}
       panels={data.panels}
-      sceneId={activeScene.id}
-      activeLayers={layerState.set}
-      focusElementId={focusElement?.id}
-      onSceneChange={handleSceneChange}
-      onLayerChange={handleLayerChange}
+      activeLayers={viewState.layerState.set}
+      focusElementId={viewState.focusElement?.id}
       onFocusChange={handleFocusChange}
+      onNavigate={handleNavigate}
     />
   )
 }
@@ -242,7 +194,9 @@ function getDefaultLayers(scene: Scene) {
 
 function deriveLayerState(scene: Scene, layerParam: string | undefined): LayerState {
   const parsed = parseRouteLayers(layerParam)
-  const valid = parsed.values.filter((layerId) => scene.layers.some((layer) => layer.id === layerId))
+  const valid = parsed.values.filter((layerId) =>
+    scene.layers.some((layer: SceneLayer) => layer.id === layerId),
+  )
 
   if (valid.length > 0) {
     return { set: new Set(valid), explicitEmpty: false }
@@ -253,17 +207,6 @@ function deriveLayerState(scene: Scene, layerParam: string | undefined): LayerSt
   }
 
   return { set: getDefaultLayers(scene), explicitEmpty: false }
-}
-
-function sanitizeLayersFromArray(scene: Scene, layers: string[] | undefined): LayerState {
-  if (!layers || layers.length === 0) {
-    return { set: getDefaultLayers(scene), explicitEmpty: false }
-  }
-  const valid = layers.filter((layerId) => scene.layers.some((layer) => layer.id === layerId))
-  if (valid.length === 0) {
-    return { set: getDefaultLayers(scene), explicitEmpty: false }
-  }
-  return { set: new Set(valid), explicitEmpty: false }
 }
 
 function parseRouteLayers(layerParam: string | undefined) {
@@ -279,13 +222,11 @@ function parseRouteLayers(layerParam: string | undefined) {
   }
 }
 
-type RouteState = {
-  sceneId: string
-  focusId?: string
-  layers?: string[] | null
-}
-
-function serializeLayers(scene: Scene, layers: Set<string>, explicitEmpty: boolean): string[] | null | undefined {
+function serializeLayers(
+  scene: Scene,
+  layers: Set<string>,
+  explicitEmpty: boolean,
+): string[] | null | undefined {
   if (explicitEmpty) {
     return null
   }
@@ -308,23 +249,106 @@ function serializeLayers(scene: Scene, layers: Set<string>, explicitEmpty: boole
   return Array.from(layers).sort()
 }
 
-function buildRoute({ sceneId, focusId, layers }: RouteState) {
-  let path = `scene/${encodeURIComponent(sceneId)}`
+function buildSearch(scene: Scene, layerState: LayerState, focusId?: string) {
+  const params = new URLSearchParams()
+  const serializedLayers = serializeLayers(scene, layerState.set, layerState.explicitEmpty)
 
   if (focusId) {
-    path += `/focus/${encodeURIComponent(focusId)}`
+    params.set('focus', focusId)
   }
 
-  if (layers !== undefined) {
-    if (layers === null || layers.length === 0) {
-      path += '/layers/_'
-    } else {
-      const serialized = layers.map((layer) => encodeURIComponent(layer)).join(',')
-      path += `/layers/${serialized}`
+  if (serializedLayers !== undefined) {
+    params.set('layers', serializedLayers === null ? '_' : serializedLayers.join(','))
+  }
+
+  return params.toString()
+}
+
+function buildPath(sceneId: string, search: string) {
+  const base = `scene/${encodeURIComponent(sceneId)}`
+  return search ? `${base}?${search}` : base
+}
+
+function pushRoute(
+  navigate: NavigateFunction,
+  scene: Scene,
+  layerState: LayerState,
+  focusId?: string,
+) {
+  const search = buildSearch(scene, layerState, focusId)
+  const path = buildPath(scene.id, search)
+  navigate(path)
+}
+
+type SanitizeInput = {
+  data: DataBundle
+  scenesMap: Map<string, Scene>
+  elementsMap: Map<string, HubElement>
+  requestedSceneId?: string
+  focusId?: string
+  layersParam?: string
+}
+
+function sanitizeRoute({
+  data,
+  scenesMap,
+  elementsMap,
+  requestedSceneId,
+  focusId,
+  layersParam,
+}: SanitizeInput) {
+  const fallbackScene = scenesMap.get(data.config.defaultScene) ?? data.scenes[0]
+  let scene = requestedSceneId ? scenesMap.get(requestedSceneId) ?? fallbackScene : fallbackScene
+
+  const focusElement = focusId ? elementsMap.get(focusId) : undefined
+  if (focusElement) {
+    const focusScene = scenesMap.get(focusElement.sceneId)
+    if (focusScene) {
+      scene = focusScene
     }
   }
 
-  return path
+  const layerState = deriveLayerState(scene, layersParam)
+  const resolvedFocus = focusElement && focusElement.sceneId === scene.id ? focusElement : undefined
+  const search = buildSearch(scene, layerState, resolvedFocus?.id)
+
+  return {
+    scene,
+    focusElement: resolvedFocus,
+    layerState,
+    search,
+  }
+}
+
+function getLegacySegment(remainder: string | undefined, key: string) {
+  if (!remainder) {
+    return undefined
+  }
+
+  const segments = remainder.split('/').filter(Boolean)
+  for (let index = 0; index < segments.length; index += 2) {
+    const segmentKey = segments[index]
+    const segmentValue = segments[index + 1]
+    if (segmentKey === key && segmentValue) {
+      return decodeURIComponent(segmentValue)
+    }
+  }
+
+  return undefined
+}
+
+function HubExperienceWrapper() {
+  return <HubExperience />
+}
+
+function App() {
+  const element = useRoutes([
+    { path: '/', element: <HubExperienceWrapper /> },
+    { path: 'scene/:sceneId/*', element: <HubExperienceWrapper /> },
+    { path: '*', element: <Navigate to="/" replace /> },
+  ])
+
+  return element
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,7 +265,7 @@ function buildSearch(scene: Scene, layerState: LayerState, focusId?: string) {
 }
 
 function buildPath(sceneId: string, search: string) {
-  const base = `scene/${encodeURIComponent(sceneId)}`
+  const base = `/scene/${encodeURIComponent(sceneId)}`
   return search ? `${base}?${search}` : base
 }
 

--- a/src/components/CampHub.tsx
+++ b/src/components/CampHub.tsx
@@ -3,22 +3,27 @@ import { MapContainer, ImageOverlay, Marker, Tooltip, useMap } from 'react-leafl
 import L, { CRS, type LeafletKeyboardEvent } from 'leaflet'
 import classNames from 'classnames'
 import ReactMarkdown from 'react-markdown'
-import type { HubConfig, HubElement, Panel, Scene, TableCell } from '../lib/types'
+import type {
+  HubConfig,
+  HubElement,
+  HubNavigationTarget,
+  Panel,
+  Scene,
+  TableCell,
+} from '../lib/types'
 import { markdownContentToString } from '../lib/markdown'
 import { useFocusTrap } from '../lib/useFocusTrap'
 import 'leaflet/dist/leaflet.css'
 
 type CampHubProps = {
   config: HubConfig
-  scenes: Scene[]
+  scene: Scene
   elements: HubElement[]
   panels: Panel[]
-  sceneId: string
   activeLayers: Set<string>
   focusElementId?: string
-  onSceneChange: (sceneId: string) => void
-  onLayerChange: (layers: Set<string>) => void
   onFocusChange: (elementId?: string) => void
+  onNavigate: (target: HubNavigationTarget) => void
 }
 
 type ActivePanel = {
@@ -48,7 +53,7 @@ type SceneCanvasProps = {
   panelsMap: Map<string, Panel>
   activeLayers: Set<string>
   focusElementId?: string
-  onElementFocus: (element: HubElement) => void
+  onElementActivate: (element: HubElement) => void
 }
 
 function SceneCanvas({
@@ -57,7 +62,7 @@ function SceneCanvas({
   panelsMap,
   activeLayers,
   focusElementId,
-  onElementFocus,
+  onElementActivate,
 }: SceneCanvasProps) {
   const filtered = useMemo(() => {
     return elements.filter((element) => activeLayers.has(element.layerId))
@@ -88,19 +93,23 @@ function SceneCanvas({
       <FocusController focusElementId={focusElementId} elements={filtered} />
       {filtered.map((element) => {
         const panel = element.panelId ? panelsMap.get(element.panelId) : undefined
-        const isClickable = Boolean(panel)
+        const hasNavigation = Boolean(element.navigation)
+        const isInteractive = Boolean(panel || hasNavigation)
         const isPin = element.icon?.kind === 'pin'
         const icon = isPin
-          ? pinIcon(element.icon?.colorVar ? `var(${element.icon.colorVar})` : undefined, !isClickable)
+          ? pinIcon(
+              element.icon?.colorVar ? `var(${element.icon.colorVar})` : undefined,
+              !isInteractive,
+            )
           : element.sprite
             ? spriteIcon(
                 element.sprite.src,
                 element.sprite.width,
                 element.sprite.height,
                 element.sprite.rotation,
-                !isClickable,
+                !isInteractive,
               )
-            : pinIcon(undefined, !isClickable)
+            : pinIcon(undefined, !isInteractive)
         const tooltip = element.name
 
         return (
@@ -109,21 +118,21 @@ function SceneCanvas({
             position={[element.position[1], element.position[0]]}
             icon={icon}
             eventHandlers={
-              isClickable
+              isInteractive
                 ? {
                     click: () => {
-                      onElementFocus(element)
+                      onElementActivate(element)
                     },
                     keydown: (event: LeafletKeyboardEvent) => {
                       if (event.originalEvent.key === 'Enter') {
-                        onElementFocus(element)
+                        onElementActivate(element)
                       }
                     },
                   }
                 : undefined
             }
-            keyboard={isClickable}
-            opacity={isClickable ? 1 : 0.6}
+            keyboard={isInteractive}
+            opacity={isInteractive ? 1 : 0.6}
             title={tooltip}
             aria-label={tooltip}
           >
@@ -188,66 +197,47 @@ function SizeInvalidator({ width, height }: SizeInvalidatorProps) {
 
 export function CampHub({
   config,
-  scenes,
+  scene,
   elements,
   panels,
-  sceneId,
   activeLayers,
   focusElementId,
-  onSceneChange,
-  onLayerChange,
   onFocusChange,
+  onNavigate,
 }: CampHubProps) {
   const [activePanel, setActivePanel] = useState<ActivePanel | null>(null)
   const drawerRef = useRef<HTMLElement | null>(null)
   const missingPanelsLogged = useRef(new Set<string>())
-  const missingScenesLogged = useRef(new Set<string>())
   useFocusTrap(Boolean(activePanel), drawerRef)
 
-  const scenesMap = useMemo(() => new Map(scenes.map((scene) => [scene.id, scene])), [scenes])
   const panelsMap = useMemo(() => new Map(panels.map((panel) => [panel.id, panel])), [panels])
 
-  const validElements = useMemo(() => {
-    return elements.filter((element) => {
-      const hasScene = scenesMap.has(element.sceneId)
-      if (!hasScene && !missingScenesLogged.current.has(element.id)) {
-        console.warn(`Elemento "${element.id}" ignorado: escena "${element.sceneId}" no existe`)
-        missingScenesLogged.current.add(element.id)
-      }
-      return hasScene
-    })
-  }, [elements, scenesMap])
-
-  const activeScene = scenesMap.get(sceneId) ?? scenes[0]
-  const resolvedScene = activeScene
-    ? {
-        ...activeScene,
-        background: resolveAsset(config.assetsBaseUrl, activeScene.background),
-      }
-    : undefined
-
-  const sceneElements = useMemo(
-    () => validElements.filter((element) => element.sceneId === activeScene?.id),
-    [validElements, activeScene?.id],
-  )
+  const resolvedScene = useMemo(() => {
+    return {
+      ...scene,
+      background: resolveAsset(config.assetsBaseUrl, scene.background),
+    }
+  }, [scene, config.assetsBaseUrl])
 
   const resolvedSceneElements = useMemo(() => {
-    return sceneElements.map((element) => {
-      if (element.panelId && !panelsMap.has(element.panelId) && !missingPanelsLogged.current.has(element.panelId)) {
-        console.warn(`Panel "${element.panelId}" no existe para el elemento "${element.id}"`)
-        missingPanelsLogged.current.add(element.panelId)
-      }
-      return {
-        ...element,
-        sprite: element.sprite
-          ? {
-              ...element.sprite,
-              src: resolveAsset(config.assetsBaseUrl, element.sprite.src),
-            }
-          : undefined,
-      }
-    })
-  }, [sceneElements, config.assetsBaseUrl, panelsMap])
+    return elements
+      .filter((element) => element.sceneId === scene.id)
+      .map((element) => {
+        if (element.panelId && !panelsMap.has(element.panelId) && !missingPanelsLogged.current.has(element.panelId)) {
+          console.warn(`Panel "${element.panelId}" no existe para el elemento "${element.id}"`)
+          missingPanelsLogged.current.add(element.panelId)
+        }
+        return {
+          ...element,
+          sprite: element.sprite
+            ? {
+                ...element.sprite,
+                src: resolveAsset(config.assetsBaseUrl, element.sprite.src),
+              }
+            : undefined,
+        }
+      })
+  }, [elements, scene.id, config.assetsBaseUrl, panelsMap])
 
   const focusElement = useMemo(() => {
     return focusElementId ? resolvedSceneElements.find((element) => element.id === focusElementId) : undefined
@@ -259,21 +249,25 @@ export function CampHub({
       return
     }
     const panel = focusElement.panelId ? panelsMap.get(focusElement.panelId) : undefined
+    if (!panel) {
+      setActivePanel(null)
+      return
+    }
     setActivePanel({ element: focusElement, panel })
   }, [focusElement, panelsMap])
 
-  const toggleLayer = (layerId: string) => {
-    const next = new Set(activeLayers)
-    if (next.has(layerId)) {
-      next.delete(layerId)
-    } else {
-      next.add(layerId)
+  const handleElementActivate = (element: HubElement) => {
+    if (element.navigation) {
+      setActivePanel(null)
+      onNavigate(element.navigation)
+      return
     }
-    onLayerChange(next)
-  }
 
-  const handleElementFocus = (element: HubElement) => {
     const panel = element.panelId ? panelsMap.get(element.panelId) : undefined
+    if (!panel) {
+      return
+    }
+
     setActivePanel({ element, panel })
     onFocusChange(element.id)
   }
@@ -283,59 +277,18 @@ export function CampHub({
     onFocusChange(undefined)
   }
 
-  if (!activeScene) {
-    return <div className="camp-hub__empty-state">No hay escenas disponibles.</div>
-  }
-
   return (
     <div className="camp-hub">
-      <header className="camp-hub__toolbar">
-        <h1 className="camp-hub__title">{config.title}</h1>
-        <nav className="camp-hub__scenes" aria-label="Escenas">
-          {scenes.map((scene) => (
-            <button
-              key={scene.id}
-              type="button"
-              className={classNames('camp-hub__scene-chip', {
-                'camp-hub__scene-chip--active': scene.id === activeScene.id,
-              })}
-              onClick={() => {
-                setActivePanel(null)
-                onFocusChange(undefined)
-                onSceneChange(scene.id)
-              }}
-            >
-              {scene.name}
-            </button>
-          ))}
-        </nav>
-        <nav className="camp-hub__layers" aria-label="Capas">
-          {activeScene.layers.map((layer) => (
-            <button
-              key={layer.id}
-              type="button"
-              className={classNames('camp-hub__layer-chip', {
-                'camp-hub__layer-chip--active': activeLayers.has(layer.id),
-              })}
-              onClick={() => toggleLayer(layer.id)}
-            >
-              {layer.name}
-            </button>
-          ))}
-        </nav>
-      </header>
       <main className="camp-hub__canvas">
-        {resolvedScene && (
-          <SceneCanvas
-            key={resolvedScene.id}
-            scene={resolvedScene}
-            elements={resolvedSceneElements}
-            panelsMap={panelsMap}
-            activeLayers={activeLayers}
-            focusElementId={focusElementId}
-            onElementFocus={handleElementFocus}
-          />
-        )}
+        <SceneCanvas
+          key={resolvedScene.id}
+          scene={resolvedScene}
+          elements={resolvedSceneElements}
+          panelsMap={panelsMap}
+          activeLayers={activeLayers}
+          focusElementId={focusElementId}
+          onElementActivate={handleElementActivate}
+        />
       </main>
       <aside
         className={classNames('camp-hub__drawer', { 'camp-hub__drawer--open': Boolean(activePanel) })}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,12 @@ export type SpriteIcon = {
 
 export type ElementIcon = PinIcon | SpriteIcon
 
+export type HubNavigationTarget = {
+  sceneId: string
+  focusId?: string
+  layers?: string[] | null
+}
+
 export type HubElement = {
   id: string
   sceneId: string
@@ -60,6 +66,7 @@ export type HubElement = {
   badge?: {
     label: string
   }
+  navigation?: HubNavigationTarget
 }
 
 export type MarkdownBlock =


### PR DESCRIPTION
## Summary
- replace the ad-hoc routing logic with a dedicated router that normalizes scene, focus, and layer URLs
- simplify the CampHub surface so only the map and panel drawer render, and add support for element-driven scene navigation
- extend the shared types to describe navigation targets for points of interest

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea7053b7c08322826e7929125a2bb1